### PR TITLE
Add Apache2 to web tier

### DIFF
--- a/roles/webtier/tasks/main.yml
+++ b/roles/webtier/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: ensure Apache2 is installed
+  yum: name=httpd state=installed
+  become: true
+  tags: apache
+
+- name: ensure Apache2 is enabled and started
+  service: name=httpd state=started enabled=yes
+  become: true
+  tags: apache


### PR DESCRIPTION
All web tier servers should get Apache2 installed. It should run on boot and also be started immediately.