### PR TITLE
Ignore Ansible site.retry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+site.retry


### PR DESCRIPTION
Previously I was simply excluding site.retry from my commits. I should formally ignore it.